### PR TITLE
Travis: use Xcode 8.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
 language: generic
 sudo: required
 dist: trusty
-osx_image: xcode8.2
+osx_image: xcode8.3
 install:
   - eval "$(curl -sL https://gist.githubusercontent.com/kylef/5c0475ff02b7c7671d2a/raw/9f442512a46d7a2af7b850d65a7e9bd31edfb09b/swiftenv-install.sh)"
 script:


### PR DESCRIPTION
And hopefully fix this error in Travis (https://travis-ci.org/kareman/FileSmith/jobs/219015311):

```
521.96s$ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pod repo update --silent; pod lib lint --allow-warnings; fi
warning: inexact rename detection was skipped due to too many files.
warning: you may want to set your diff.renameLimit variable to at least 22972 and retry the command.
 -> FileSmith (0.1.2)
    - ERROR | xcodebuild: Returned an unsuccessful exit code. You can use `--verbose` for more information.
[!] FileSmith did not pass validation, due to 1 error.
You can use the `--no-clean` option to inspect any issue.
The command "if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pod repo update --silent; pod lib lint --allow-warnings; fi" exited with 1.
Done. Your build exited with 1.
/Users/travis/.travis/job_stages: line 150: shell_session_update: command not found
```