### PR TITLE
Added products section so it can be added to Xcode projects as a library

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,9 @@ import PackageDescription
 
 let package = Package(
 	name: "FileSmith",
+	products: [
+            .library(name: "FileSmith", targets: ["FileSmith"])
+        ],
 	dependencies: [
 		// Dependencies declare other packages that this package depends on.
 		.package(url: "https://github.com/kareman/SwiftShell.git", from: "4.1.0")


### PR DESCRIPTION
A missing products section in the Package.swift file meant that running `swift package generate-xcodeproj` would fail with error indicating that the FileSmith dependency was not being used and the  target dependency reference was not found. The actual problem seem to be that SPM was not recognising FileSmith as a library so adding this section made the connection.